### PR TITLE
webhookのHTTP POSTヘッダーにContent-Typeが設定されていないため追加

### DIFF
--- a/util.go
+++ b/util.go
@@ -27,6 +27,7 @@ func PostRequest(reqUrl string, reqBody interface{}) ([]byte, error) {
 		logger.Info("post request error, error=", err)
 		return nil, err
 	}
+	req.Header.Set("Content-Type", "application/json")
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {


### PR DESCRIPTION
サーバアプリケーションによっては、POSTリクエストデータの
JSONをパース出来ない場合があるため、追加をお願いしたいです。