### PR TITLE
文字列のnullが渡された際にruntime errorで落ちる不具合を修正

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -246,6 +246,10 @@ loop:
 // メッセージ系のエラーログはここですべて取る
 func (c *connection) handleWsMessage(rawMessage []byte, pongTimeoutTimer *time.Timer) error {
 	message := &message{}
+	if string(rawMessage) == "null" {
+		c.errLog().Bytes("rawMessage", rawMessage).Msg("InvalidJSON")
+		return errInvalidJSON
+	}
 	if err := json.Unmarshal(rawMessage, &message); err != nil {
 		c.errLog().Err(err).Bytes("rawMessage", rawMessage).Msg("InvalidJSON")
 		return errInvalidJSON


### PR DESCRIPTION
Ayame Web SDKを使わずにAyameに接続しようとした際に発生した不具合の修正プルリクエストです。
Ayameに対して、WebSocketで文字列の `null` を送信すると、以下の内容のエラーでAyameが落ちます。

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x12f5591]

goroutine 11 [running]:
main.(*connection).handleWsMessage(0xc00014c500, 0xc0000a8000, 0x4, 0x600, 0xc00006e3c0, 0x0, 0x0)
	/Users/sublimer/workspace/oss/ayame/connection.go:255 +0x1c1
main.(*connection).main(0xc00014c500, 0xc000158850, 0xc000064ae0)
	/Users/sublimer/workspace/oss/ayame/connection.go:182 +0x243
created by main.signalingHandler
	/Users/sublimer/workspace/oss/ayame/signaling_handler.go:48 +0x280
```

受け取ったデータが文字列の `null` かどうか判定するコードを追加しました。
文字列の `null` の場合は、 `InvalidJSON` としてWebSocketの接続を切断します。
クライアント側の不具合再現コードはこちらです。

```js
const ws = new WebSocket('ws://127.0.0.1:3000/signaling');

ws.onopen = () => {
    console.log('open');
    ws.send('null');
}
```

修正の方針に沿っていないようでしたら、このPRは却下していただいて構いません。