### PR TITLE
ロックに関するコメント修正

### DIFF
--- a/server.go
+++ b/server.go
@@ -16,9 +16,7 @@ type room struct {
 func server() {
 	// room を管理するマップはここに用意する
 	var m = make(map[string]room)
-	// ここはシングルなのでmap読み書きに関してロックは不要
-	// 他スレッド間と共有されるregister, unregisterに関しては参照のみ行うので、このスレッドは他スレッドに影響及ぼさない
-	// また、connectionの状態変化は限定的(register時のみ)なので、外部スレッドもこのスレッドに影響を及ぼさない
+	// ここはシングルなのでロックは不要
 	for {
 		select {
 		case register := <-registerChannel:

--- a/server.go
+++ b/server.go
@@ -16,7 +16,9 @@ type room struct {
 func server() {
 	// room を管理するマップはここに用意する
 	var m = make(map[string]room)
-	// ここはシングルなのでロックは不要、多分
+	// ここはシングルなのでmap読み書きに関してロックは不要
+	// 他スレッド間と共有されるregister, unregisterに関しては参照のみ行うので、このスレッドは他スレッドに影響及ぼさない
+	// また、connectionの状態変化は限定的(register時のみ)なので、外部スレッドもこのスレッドに影響を及ぼさない
 	for {
 		select {
 		case register := <-registerChannel:


### PR DESCRIPTION
コメントに不安を感じたので調べてみました。

現状スレッドは

- server
- connectionごとにmain, wsRecv

があって、スレッド跨いで共有されている構造は

- register, unregister (chanを通してポインタを渡すことでスレッド間で共有されている)

だけに見えます。なのでその辺を追ってみましたが、

- serverスレッドは自身のroomMapとそれに格納されているroomしか更新していない
- serverスレッドはchanから飛んできたregister/unregisterは参照しかしていない
- serverに投げたmainスレッドはserverに投げている間ブロックされる

ということからconnectionのフィールドは複数スレッドで同時に更新されることはありません。
あとgoのmapはconcurrent mapではないとのことなのでread/writeを同時にするとクラッシュしますが、

- serverはmap(roomMap)をread/writeしているけどここはシングルスレッドだからOk
- 同じくmap(room.connections)もread/writeしているけどシングルスレッドだからread/writeが同時に走ることはなくOk

と考えられます。
以上を元にコメントを修正しました。