### PR TITLE
GO111MODULE を削除する

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,9 @@
-GO111MODULE = on
 LDFLAGS = -ldflags '-w -s'
 
 .PHONY: ayame
 
 ayame:
-	GO111MODULE=$(GO111MODULE) go build $(LDFLAGS) -o $@
+	go build $(LDFLAGS) -o $@
 
 .PHONY: darwin linux
 
@@ -12,10 +11,10 @@ GOOS = $@
 GOARCH = amd64
 
 linux darwin:
-	GO111MODULE=$(GO111MODULE) GOOS=$(GOOS) GOARCH=$(GOARCH) go build $(LDFLAGS) -o ayame-$(GOOS)
+	GOOS=$(GOOS) GOARCH=$(GOARCH) go build $(LDFLAGS) -o ayame-$(GOOS)
 
 check:
-	GO111MODULE=$(GO111MODULE) go test ./...
+	go test ./...
 
 clean:
 	rm -rf ayame


### PR DESCRIPTION
デフォルトで GO111MODULE=on としてビルドするため、Makefile から GO111MODULE の指定を削除します