### PR TITLE
main.go から testing を削除する

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"testing"
 	"time"
 
 	"github.com/rs/zerolog"
@@ -29,7 +28,6 @@ var (
 
 // 初期化処理
 func init() {
-	testing.Init()
 	configFilePath := flag.String("c", "./ayame.yaml", "ayame の設定ファイルへのパス(yaml)")
 	flag.Parse()
 	// yaml ファイルを読み込み


### PR DESCRIPTION
main.go に testing.Init() が含まれていたため、$ ./ayame -h で表示される Usage に -test.bench regexp, -test.benchmem 等のオプションが含まれていたため、testing.Init() を削除して不要なオプションが含まれないようにしています