### PR TITLE
standalone モードの追加

### DIFF
--- a/healthcheck_handler.go
+++ b/healthcheck_handler.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func healthcheckHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprint(w, "")
+}

--- a/main.go
+++ b/main.go
@@ -91,9 +91,8 @@ func main() {
 
 	go server()
 
-	http.HandleFunc("/signaling", func(w http.ResponseWriter, r *http.Request) {
-		signalingHandler(w, r)
-	})
+	http.HandleFunc("/signaling", signalingHandler)
+	http.HandleFunc("/.ok", healthcheckHandler)
 	server := &http.Server{Addr: url, Handler: nil, ReadHeaderTimeout: readHeaderTimeout}
 
 	if err := server.ListenAndServe(); err != nil {

--- a/ws_messages.go
+++ b/ws_messages.go
@@ -17,6 +17,7 @@ type registerMessage struct {
 	AyameClient *string `json:"ayameClient"`
 	Libwebrtc   *string `json:"libwebrtc"`
 	Environment *string `json:"environment"`
+	Standalone  bool    `json:"standalone"`
 }
 
 type pingMessage struct {


### PR DESCRIPTION
ヘルスチェックと、接続完了後に WebSocket を切断する standalone モードを追加しました

- type: register 時に standalone: true の場合は、接続完了後にクライアントが送信してくる type: connected を受信後に WebSocket を切断します
- 接続後に WebSocket は切断するため、standalone モードの場合は PING は送信しません