### PR TITLE
debug = true の場合にのみ signaling.log に rawMessage を出力するように変更する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,8 @@
   - @voluntas
 - [ADD] リリースバイナリに linux arm64 を追加する
   - @voluntas
+- [CHANGE] debug 設定が有効な場合にのみ、signaling.log に受信したシグナリングの生データを出力するように変更する
+  - @Hexa
 
 ## 2023.2.0
 

--- a/connection_log.go
+++ b/connection_log.go
@@ -7,12 +7,21 @@ import (
 
 func (c *connection) signalingLog(message message, rawMessage []byte) {
 	if message.Type != "pong" {
-		c.signalingLogger.Log().
-			Str("roomId", c.roomID).
-			Str("clientID", c.clientID).
-			Str("connectionId", c.ID).
-			Str("type", message.Type).
-			Msg(string(rawMessage))
+		if c.config.Debug {
+			c.signalingLogger.Log().
+				Str("roomId", c.roomID).
+				Str("clientID", c.clientID).
+				Str("connectionId", c.ID).
+				Str("type", message.Type).
+				Msg(string(rawMessage))
+		} else {
+			c.signalingLogger.Log().
+				Str("roomId", c.roomID).
+				Str("clientID", c.clientID).
+				Str("connectionId", c.ID).
+				Str("type", message.Type).
+				Send()
+		}
 	}
 }
 


### PR DESCRIPTION
This pull request includes changes to control the logging of raw signaling data based on the debug setting. The changes ensure that raw signaling data is only logged when the debug setting is enabled.

Changes to logging behavior:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R20-R21): Added a change log entry indicating that raw signaling data is logged to `signaling.log` only when the debug setting is enabled.
* [`connection_log.go`](diffhunk://#diff-8b887b9ad30e3abc123ef17ba73b892825f65bf7afc7d2cc60b267b8f6ccfc83R10-R24): Updated the `signalingLog` function to conditionally log raw signaling data based on the `Debug` configuration setting.