### PR TITLE
任意のメッセージの送信に使用する type: message を追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,11 @@
   - @voluntas
 - [ADD] リリースバイナリに linux arm64 を追加する
   - @voluntas
+- [ADD] シグナリングで任意のメッセージの送信を有効にする type_message 設定を追加する
+  - デフォルト値: false（type: message 無効）
+  - @Hexa
+- [ADD] シグナリングで任意のメッセージの送信時に指定する type: message を追加する
+  - @Hexa
 
 ## 2023.2.0
 

--- a/config.go
+++ b/config.go
@@ -29,6 +29,8 @@ type Config struct {
 	LogLevel         string `ini:"log_level"`
 	SignalingLogName string `ini:"signaling_log_name"`
 
+	TypeMessage bool `ini:"type_message"`
+
 	ListenIPv4Address string `ini:"listen_ipv4_address"`
 	ListenPortNumber  int32  `ini:"listen_port_number"`
 

--- a/config_example.ini
+++ b/config_example.ini
@@ -4,6 +4,8 @@ log_name = ayame.log
 log_level = debug
 signaling_log_name = signaling.log
 
+type_message = false
+
 listen_ipv4_address = 0.0.0.0
 listen_port_number = 3000
 

--- a/connection.go
+++ b/connection.go
@@ -400,6 +400,19 @@ func (c *connection) handleWsMessage(rawMessage []byte, pongTimeoutTimer *time.T
 			return errRegistrationIncomplete
 		}
 		c.forward(rawMessage)
+	case "message":
+		// 設定が有効でなければ default と同じ処理
+		if !c.config.TypeMessage {
+			c.errLog().Msg("InvalidMessageType")
+			return errInvalidMessageType
+		}
+
+		// register が完了していない
+		if !c.registered {
+			c.errLog().Msg("RegistrationIncomplete")
+			return errRegistrationIncomplete
+		}
+		c.forward(rawMessage)
 	case "connected":
 		// register が完了していない
 		if !c.registered {


### PR DESCRIPTION
This pull request introduces a new feature to enable the sending of arbitrary messages in signaling by adding a `type_message` configuration. Additionally, it includes updates to the configuration files and handling logic to support this new feature.

Key changes:

### New Feature Addition:
* Added `type_message` configuration to enable or disable the sending of arbitrary messages in signaling. The default value is set to `false`. (`config.go` [[1]](diffhunk://#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249R32-R33) `config_example.ini` [[2]](diffhunk://#diff-b85f5cca5558e6035d7f3fd0aa138ab1b719fa05e562a61c27ad75fe7a760d94R7-R8)

### Configuration Updates:
* Updated `CHANGES.md` to document the addition of the `type_message` setting and its default value. (`CHANGES.md` [CHANGES.mdR20-R24](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R20-R24))

### Handling Logic:
* Modified the `handleWsMessage` function to include logic for handling the new `message` type. It checks if the `type_message` configuration is enabled and if the connection is registered before forwarding the message. (`connection.go` [connection.goR397-R409](diffhunk://#diff-25a7cf08cc8fc8eb57475835cc380524de2fd1215cda9c6915132ae86dbd80a7R397-R409))