### PR TITLE
Feature/custom log key

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,10 @@
 
 ## develop
 
+- [ADD] ログのメッセージキー名とタイムスタンプキー名を指定できるようにする
+  - `log_message_key_name` と `log_timestamp_key_name` を追加する
+  - @voluntas
+
 ## 2025.4.0
 
 - [ADD] シグナリングで利用する WebSocket の HTTP ヘッダーをウェブフックにコピーする `copy_websocket_header_names` 設定を追加する

--- a/config.go
+++ b/config.go
@@ -58,6 +58,9 @@ type Config struct {
 	LogRotateMaxAge     int    `ini:"log_rotate_max_age"`
 	LogRotateCompress   bool   `ini:"log_rotate_compress"`
 
+	LogMessageKeyName   string `ini:"log_message_key_name"`
+	LogTimestampKeyName string `ini:"log_timestamp_key_name"`
+
 	SignalingLogName    string   `ini:"signaling_log_name"`
 	SignalingLogFilters []string `ini:"signaling_log_filters"`
 

--- a/config_example.ini
+++ b/config_example.ini
@@ -26,6 +26,14 @@
 ## デフォルトは false です
 # log_rotate_compress = true
 
+## ログのメッセージキー名を指定します
+## デフォルトは message です
+# log_message_key_name = message
+
+## ログのタイムスタンプキー名を指定します
+## デフォルトは time です
+# log_timestamp_key_name = time
+
 ## シグナリングログのファイル名を指定します
 ## デフォルトは signaling.jsonl です
 # signaling_log_name = signaling.jsonl

--- a/logger.go
+++ b/logger.go
@@ -19,6 +19,13 @@ func InitLogger(config *Config) error {
 
 	zerolog.TimeFieldFormat = time.RFC3339Nano
 
+	if config.LogMessageKeyName != "" {
+		zerolog.MessageFieldName = config.LogMessageKeyName
+	}
+	if config.LogTimestampKeyName != "" {
+		zerolog.TimestampFieldName = config.LogTimestampKeyName
+	}
+
 	if config.Debug {
 		zerolog.SetGlobalLevel(zerolog.DebugLevel)
 	} else {


### PR DESCRIPTION
This pull request introduces a new feature that allows users to customize the key names for log messages and timestamps. The most important changes include updates to configuration options, example configuration files, and logger initialization to support this feature.

### Configuration updates:
* Added `LogMessageKeyName` and `LogTimestampKeyName` fields to the `Config` struct to allow customization of log message and timestamp key names. (`config.go`, [config.goR61-R63](diffhunk://#diff-0e426a43248661127a0c0ee115aef7a1093b635f8993b3f7ebb1dd9f05b8f249R61-R63))

### Example configuration:
* Updated `config_example.ini` to include examples and descriptions for the new `log_message_key_name` and `log_timestamp_key_name` settings. (`config_example.ini`, [config_example.iniR29-R36](diffhunk://#diff-b85f5cca5558e6035d7f3fd0aa138ab1b719fa05e562a61c27ad75fe7a760d94R29-R36))

### Logger initialization:
* Modified the `InitLogger` function to set `zerolog.MessageFieldName` and `zerolog.TimestampFieldName` based on the new configuration fields if they are provided. (`logger.go`, [logger.goR22-R28](diffhunk://#diff-ff87b7c4777a35588053a509583d66c9f404ccbea9e1c71d2a5f224d7ad1323eR22-R28))

### Documentation:
* Updated `CHANGES.md` to document the addition of the `log_message_key_name` and `log_timestamp_key_name` configuration options. (`CHANGES.md`, [CHANGES.mdR14-R17](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R14-R17))